### PR TITLE
Task-043: Añadir botón para enviar los resultados a Telegram- Reyes - Funcionalidad

### DIFF
--- a/decide/visualizer/templates/visualizer/visualizer.html
+++ b/decide/visualizer/templates/visualizer/visualizer.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block content %}
-    {% comment %} <div id="app-visualizer">
+    <div id="app-visualizer">
         <!-- Navbar -->
         <b-navbar type="dark" variant="secondary">
             <b-navbar-brand tag="h1">Decide</b-navbar-brand>
@@ -19,6 +19,7 @@
         <div class="voting container">
             <h1>[[ voting.id ]] - [[ voting.name ]]</h1>
 
+            <a href={{botUrl}} style="float:right;" class="btn btn-outline-dark" target="_blank">Enviar resultados por Telegram </a>
             <h2 v-if="!voting.start_date">Votación no comenzada</h2>
             <h2 v-else-if="!voting.end_date">Votación en curso</h2>
             <div v-else>
@@ -54,7 +55,7 @@
             </div>
 
         </div>
-    </div> {% endcomment %}
+    </div>
 {% endblock %}
 
 {% block extrabody %}

--- a/decide/visualizer/views.py
+++ b/decide/visualizer/views.py
@@ -6,9 +6,6 @@ from django.http import Http404
 from base import mods
 
 import telegram
-import requests
-from django.shortcuts import render
-
 
 BOT_TOKEN="1458371772:AAHu7wPpi_gZNSIvwQfUeMndzffycghAVaw"
 BOT_CHAT_ID="-406008177"
@@ -101,6 +98,7 @@ class VisualizerView(TemplateView):
         try:
             r = mods.get('voting', params={'id': vid})
             context['voting'] = json.dumps(r[0])
+            context['botUrl']="http://localhost:8000/visualizer/botResults/"+str(r[0]['id'])
         except:
             raise Http404
 


### PR DESCRIPTION
Se ha añadido un botón para enviar los resultados de la votación a Telegram. Al pulsar el botón, se abrirá una nueva pestaña que indique si se ha realizado correctamente la acción