### PR TITLE
Task-054: Error al intentar enviar el mensaje con los resultados a Telegram - Reyes - Correcciones

### DIFF
--- a/decide/visualizer/views.py
+++ b/decide/visualizer/views.py
@@ -8,7 +8,7 @@ from base import mods
 import telegram
 
 BOT_TOKEN="1458371772:AAHu7wPpi_gZNSIvwQfUeMndzffycghAVaw"
-BOT_CHAT_ID="-406008177"
+BOT_CHAT_ID="@guadalfeo_visualizacion"
 BOT_URL="https://api.telegram.org/bot"+BOT_TOKEN+"/sendMessage?chat_id="+BOT_CHAT_ID+"&text=Hello+world"
 
 def bot(voting_id, msg,chat_id=BOT_CHAT_ID, token=BOT_TOKEN):


### PR DESCRIPTION
Debido al cambio de la configuración del grupo de Telegram, en el que se ha cambiado de privado a público, el id del chat ha cambiado. Se ha modificado la declaración del id del chat.