### PR TITLE
Task-067: Ordenación de los resultados-Fernando-Funcionalidad

### DIFF
--- a/decide/visualizer/views.py
+++ b/decide/visualizer/views.py
@@ -116,7 +116,18 @@ class VisualizerView(TemplateView):
             script_location = Path(__file__).absolute().parent
             file_location = script_location / 'API_vGeneral.json'
             with file_location.open() as json_file:
-                context['voting'] = json.load(json_file)
+                json_file = json.load(json_file)
+                
+            # Sorting the results
+            lista = []
+            if (json_file['tipo'] == 'VG'):
+                lista = [0,1,2,3,4,5,6]
+            else:
+                lista = [0,1,2,3,4,5]
+            for i in lista:
+                json_file['preguntas'][i]['opts'] = sorted(json_file['preguntas'][i]['opts'], key=lambda x : x['voto_M']+x['voto_F'], reverse=True)
+
+            context['voting'] = json_file
             r = mods.get('voting', params={'id': vid})
             # context['voting'] = json.dumps(r[0])
             context['botUrl']="http://localhost:8000/visualizer/botResults/"+str(r[0]['id'])


### PR DESCRIPTION
Descripción: Cuando se muestran los resultados de las votaciones en las tablas pertinentes, estos no se encuentran ordenados por el número total de votos de cada candidato, dificultando mucho la visualización de los ganadores de cada una de ellas.
Fecha: 30/12/2020
Registrado por: Fernando Luis Sola Espinosa
Cómo provocar el error: Simplemente creamos una votación con datos suficientes, la cerramos y hacemos "tally". A continuación accedemos a "Visualizer" de dicha votación y podemos verificar que al mostrar los resultados estos se encuentran desordenados dentro de cada pregunta de la votación.
Resultado correcto: Los candidatos de cada pregunta de la votación ordenados por el número de votos que han obtenido.
Plataforma usada: Google Chrome 87.0.4280.88 (Build oficial) (64 bits)