### PR TITLE
Task-176: Pruebas navegación vista resultado de votación sin finalizar-Reyes-Prueba

### DIFF
--- a/decide/visualizer/tests.py
+++ b/decide/visualizer/tests.py
@@ -77,6 +77,21 @@ class TesExport(StaticLiveServerTestCase):
         self.driver.quit()
         self.base.tearDown()
 
+    def voting_in_process(self):
+        self.driver.get("http://localhost:8000/visualizer/2")
+        self.driver.maximize_window()
+        self.assertTrue(self.driver.find_element_by_css_selector('h2')=="Votación en curso")
+
+    def voting_is_not_started(self):
+        self.driver.get("http://localhost:8000/visualizer/3")
+        self.driver.maximize_window()
+        self.assertTrue(self.driver.find_element_by_css_selector('h2')=="Votación no comenzada")
+
+    def voting_without_tally(self):
+        self.driver.get("http://localhost:8000/visualizer/4")
+        self.driver.maximize_window()
+        self.assertTrue(self.driver.find_element_by_css_selector('h2')=="Votación sin recuento")
+        
     def test_exportar_PDF(self):
         self.driver.get("http://localhost:8000/visualizer/1")
         self.driver.maximize_window()
@@ -87,4 +102,4 @@ class TesExport(StaticLiveServerTestCase):
         self.driver.get("http://localhost:8000/visualizer/1")
         self.driver.maximize_window()
         self.driver.find_element(By.LINK_TEXT,"▼ Exportar").click()
-        self.driver.find_element(By.LINK_TEXT, "Excel").click()       
+        self.driver.find_element(By.LINK_TEXT, "Excel").click()


### PR DESCRIPTION
Se han implementado las pruebas de navegación de la vista de resultados cuando la votación no esta finalizada es decir, no se ha comenzado, se ha comenzado pero no finalizado, se ha finalizado pero no se ha hecho el recuento.